### PR TITLE
Improve search performance

### DIFF
--- a/src/main/kotlin/com/machiav3lli/fdroid/utility/Utils.kt
+++ b/src/main/kotlin/com/machiav3lli/fdroid/utility/Utils.kt
@@ -444,20 +444,19 @@ fun List<PermissionInfo>.getLabelsAndDescriptions(context: Context): List<String
     }
 }
 
-fun Collection<Product>.matchSearchQuery(searchQuery: String): List<Product> = filter {
-    listOf(it.label, it.packageName, it.author.name, it.summary, it.description).any { literal ->
-        literal.matches(Regex(".*$searchQuery.*", RegexOption.IGNORE_CASE))
+fun Collection<Product>.matchSearchQuery(searchQuery: String): List<Product> {
+    if (searchQuery.isBlank()) return toList()
+    val searchRegex = Regex(searchQuery, RegexOption.IGNORE_CASE)
+    return filter {
+        listOf(it.label, it.packageName, it.author.name, it.summary, it.description)
+            .any { literal ->
+                literal.contains(searchRegex)
+            }
+    }.sortedByDescending {
+        (if ("${it.label} ${it.packageName}".contains(searchRegex)) 7 else 0) or
+                (if ("${it.summary} ${it.author.name}".contains(searchRegex)) 3 else 0) or
+                (if (it.description.contains(searchRegex)) 1 else 0)
     }
-}.sortedByDescending {
-    (if ("${it.label} ${it.packageName}"
-            .matches(Regex(".*$searchQuery.*", RegexOption.IGNORE_CASE))
-    ) 7 else 0) or
-            (if ("${it.summary} ${it.author.name}"
-                    .matches(Regex(".*$searchQuery.*", RegexOption.IGNORE_CASE))
-            ) 3 else 0) or
-            (if (it.description
-                    .matches(Regex(".*$searchQuery.*", RegexOption.IGNORE_CASE))
-            ) 1 else 0)
 }
 
 // TODO move to a new file


### PR DESCRIPTION
Proposal for fix issue #368.

Regex in general can be a little slowly, so I've made below changes to improve performance:

- Added `Flow.debounce` to dispatch query update only if user pause typing for >= 400ms;
- Ignore filter/sort if search term is empty or blank;
- Compile regex once, the expression never changes in this scope;
- Replace searching method from `matches` to `contains` without change the previous behavior.

PS: To improve a little more, we can use `.contains(searchQuery, ignoreCase = true)` instead of regex, but it will change the actual expected result.