### PR TITLE
Added a separate string for the text about the installed app

### DIFF
--- a/src/main/kotlin/com/machiav3lli/fdroid/ui/compose/components/appsheet/ReleaseItem.kt
+++ b/src/main/kotlin/com/machiav3lli/fdroid/ui/compose/components/appsheet/ReleaseItem.kt
@@ -122,7 +122,7 @@ fun ReleaseItemContent(
                     val badgeText = remember { mutableStateOf(R.string.suggested) }
                     LaunchedEffect(isInstalled, isSuggested) {
                         badgeText.value =
-                            if (isInstalled) R.string.installed else R.string.suggested
+                            if (isInstalled) R.string.app_installed else R.string.suggested
                     }
                     ReleaseBadge(
                         modifier = Modifier.padding(top = 8.dp),

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -143,6 +143,7 @@
     <string name="source_code">Source code</string>
     <string name="source_code_no_longer_available">Source code no longer available</string>
     <string name="suggested">Suggested</string>
+    <string name="app_installed">Installed</string>
     <string name="sync_repositories">Sync repositories</string>
     <string name="sync_repositories_automatically">Auto-sync repositories</string>
     <string name="syncing">Syncing</string>


### PR DESCRIPTION
This will allow you to correctly translate in other languages the word "Installed", which appears next to the installed version of the application (before installation it says "Suggested").