### PR TITLE
fix: improve performance of search on ExplorePage, LatestPage and InstalledPage

### DIFF
--- a/src/main/kotlin/com/machiav3lli/fdroid/ui/pages/ExplorePage.kt
+++ b/src/main/kotlin/com/machiav3lli/fdroid/ui/pages/ExplorePage.kt
@@ -9,12 +9,12 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -35,9 +35,8 @@ import com.machiav3lli.fdroid.ui.navigation.NavItem
 import com.machiav3lli.fdroid.ui.navigation.SideNavBar
 import com.machiav3lli.fdroid.ui.viewmodels.ExploreViewModel
 import com.machiav3lli.fdroid.utility.onLaunchClick
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @Composable
 fun ExplorePage(viewModel: ExploreViewModel) {
@@ -55,13 +54,16 @@ fun ExplorePage(viewModel: ExploreViewModel) {
         mutableStateOf(Preferences[Preferences.Key.CategoriesFilterExplore])
     }
 
-    SideEffect {
-        CoroutineScope(Dispatchers.IO).launch {
+    LaunchedEffect(Unit) {
+        withContext(Dispatchers.IO) {
             mainActivityX.searchQuery.collect { newQuery ->
                 viewModel.setSearchQuery(newQuery)
             }
         }
-        CoroutineScope(Dispatchers.Default).launch {
+    }
+
+    LaunchedEffect(Unit) {
+        withContext(Dispatchers.Default) {
             Preferences.subject.collect {
                 when (it) {
                     Preferences.Key.ReposFilterExplore,

--- a/src/main/kotlin/com/machiav3lli/fdroid/ui/pages/InstalledPage.kt
+++ b/src/main/kotlin/com/machiav3lli/fdroid/ui/pages/InstalledPage.kt
@@ -16,7 +16,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -43,9 +43,8 @@ import com.machiav3lli.fdroid.ui.compose.icons.phosphor.FunnelSimple
 import com.machiav3lli.fdroid.ui.navigation.NavItem
 import com.machiav3lli.fdroid.ui.viewmodels.InstalledViewModel
 import com.machiav3lli.fdroid.utility.onLaunchClick
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @Composable
 fun InstalledPage(viewModel: InstalledViewModel) {
@@ -60,13 +59,16 @@ fun InstalledPage(viewModel: InstalledViewModel) {
     }
     val favorites by mainActivityX.db.extrasDao.favoritesFlow.collectAsState(emptyArray())
 
-    SideEffect {
-        CoroutineScope(Dispatchers.IO).launch {
+    LaunchedEffect(Unit) {
+        withContext(Dispatchers.IO) {
             mainActivityX.searchQuery.collect { newQuery ->
                 viewModel.setSearchQuery(newQuery)
             }
         }
-        CoroutineScope(Dispatchers.Default).launch {
+    }
+
+    LaunchedEffect(Unit) {
+        withContext(Dispatchers.Default) {
             Preferences.subject.collect {
                 when (it) {
                     Preferences.Key.ReposFilterInstalled,

--- a/src/main/kotlin/com/machiav3lli/fdroid/ui/pages/LatestPage.kt
+++ b/src/main/kotlin/com/machiav3lli/fdroid/ui/pages/LatestPage.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -33,9 +33,8 @@ import com.machiav3lli.fdroid.ui.compose.utils.vertical
 import com.machiav3lli.fdroid.ui.navigation.NavItem
 import com.machiav3lli.fdroid.ui.viewmodels.LatestViewModel
 import com.machiav3lli.fdroid.utility.onLaunchClick
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @Composable
 fun LatestPage(viewModel: LatestViewModel) {
@@ -50,14 +49,17 @@ fun LatestPage(viewModel: LatestViewModel) {
     }
     val favorites by mainActivityX.db.extrasDao.favoritesFlow.collectAsState(emptyArray())
 
-    SideEffect {
+    LaunchedEffect(Unit) {
         mainActivityX.syncConnection.bind(context)
-        CoroutineScope(Dispatchers.IO).launch {
+        withContext(Dispatchers.IO) {
             mainActivityX.searchQuery.collect { newQuery ->
                 viewModel.setSearchQuery(newQuery)
             }
         }
-        CoroutineScope(Dispatchers.Default).launch {
+    }
+
+    LaunchedEffect(Unit) {
+        withContext(Dispatchers.Default) {
             Preferences.subject.collect {
                 when (it) {
                     Preferences.Key.ReposFilterLatest,


### PR DESCRIPTION
This bug seems to be ocurring due to repeatedly `collect`ing the `MainActivityX.searchQuery` StateFlow each time the composable does a recomposition due to using the `SideEffect` effect. To fix this I decided to use a `LaunchedEffect` which in this case will only run after the screen is composed for the first time.

This is intended to address the issue #368.