### PR TITLE
Add Samourai Wallet Repo

### DIFF
--- a/src/main/kotlin/com/machiav3lli/fdroid/database/entity/Repository.kt
+++ b/src/main/kotlin/com/machiav3lli/fdroid/database/entity/Repository.kt
@@ -501,6 +501,15 @@ data class Repository(
             "103063BC7189C91CE727DBF8266B07662518096E1686B6A088253933A3D0788F",
             ""
         )
+        private val SAMOURAI_WALLET = defaultRepository(
+            "https://repo.samourai.io/fdroid/repo",
+            "Official Samourai Wallet F-Droid Repo",
+            "A bitcoin wallet for the streets - hand forged to keep your transactions private ",
+            21,
+            false,
+            "5318AFA280284855CF5D0027AA54517769F461D735980B1FB0854CEAE8E072A5",
+            ""
+        )
 
         val defaultRepositories = listOf(
             F_DROID, F_DROID_ARCHIVE,
@@ -523,6 +532,7 @@ data class Repository(
             JAK_LINUX,
             INVISV, MONERUJO, IODE, SPIRIT_CROC,
             DIVEST_OS_UNOFFICIAL, FUNKWHALE,
+            SAMOURAI_WALLET,
         )
 
         val addedReposV9 = listOf(

--- a/src/main/kotlin/com/machiav3lli/fdroid/database/entity/Repository.kt
+++ b/src/main/kotlin/com/machiav3lli/fdroid/database/entity/Repository.kt
@@ -504,7 +504,7 @@ data class Repository(
         private val SAMOURAI_WALLET = defaultRepository(
             "https://repo.samourai.io/fdroid/repo",
             "Official Samourai Wallet F-Droid Repo",
-            "A bitcoin wallet for the streets - hand forged to keep your transactions private ",
+            "A bitcoin wallet for the streets - hand forged to keep your transactions private.",
             21,
             false,
             "5318AFA280284855CF5D0027AA54517769F461D735980B1FB0854CEAE8E072A5",


### PR DESCRIPTION
Adds the official F-Droid repo maintained by the devs of Samourai Wallet, a bleeding edge bitcoin wallet with a focus on privacy, see [official site](https://samouraiwallet.com/) and [repo page](https://samouraiwallet.com/download/fdroid).