### PR TITLE
installer: Set install reason as user (closes #359)

### DIFF
--- a/src/main/kotlin/com/machiav3lli/fdroid/installer/RootInstaller.kt
+++ b/src/main/kotlin/com/machiav3lli/fdroid/installer/RootInstaller.kt
@@ -1,6 +1,7 @@
 package com.machiav3lli.fdroid.installer
 
 import android.content.Context
+import android.content.pm.PackageManager
 import com.machiav3lli.fdroid.BuildConfig
 import com.machiav3lli.fdroid.MainApplication
 import com.machiav3lli.fdroid.content.Cache
@@ -49,6 +50,7 @@ class RootInstaller(context: Context) : BaseInstaller(context) {
             if (Preferences[Preferences.Key.RootAllowInstallingOldApps]) "--bypass-low-target-sdk-block" else null,
             "-i", BuildConfig.APPLICATION_ID,
             "--user", getCurrentUserState,
+            if (Android.sdk(26)) "--install-reason ${PackageManager.INSTALL_REASON_USER}" else null,
             "-t",
             "-r",
             "-S", length(),
@@ -60,6 +62,7 @@ class RootInstaller(context: Context) : BaseInstaller(context) {
             if (Preferences[Preferences.Key.RootAllowInstallingOldApps]) "--bypass-low-target-sdk-block" else null,
             "-i", BuildConfig.APPLICATION_ID,
             "--user", getCurrentUserState,
+            if (Android.sdk(26)) "--install-reason ${PackageManager.INSTALL_REASON_USER}" else null,
             "-t",
             "-r",
             "-S", length(),

--- a/src/main/kotlin/com/machiav3lli/fdroid/installer/SessionInstaller.kt
+++ b/src/main/kotlin/com/machiav3lli/fdroid/installer/SessionInstaller.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageInstaller
 import android.content.pm.PackageInstaller.SessionParams
+import android.content.pm.PackageManager
 import android.util.Log
 import com.machiav3lli.fdroid.NeoActivity
 import com.machiav3lli.fdroid.content.Cache
@@ -29,6 +30,9 @@ class SessionInstaller(context: Context) : BaseInstaller(context) {
             if (Android.sdk(31)) PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
             else PendingIntent.FLAG_UPDATE_CURRENT
         val sessionParams = SessionParams(SessionParams.MODE_FULL_INSTALL).apply {
+            if (Android.sdk(26)) {
+                setInstallReason(PackageManager.INSTALL_REASON_USER)
+            }
             if (Android.sdk(31)) {
                 setRequireUserAction(SessionParams.USER_ACTION_NOT_REQUIRED)
             }


### PR DESCRIPTION
This fixes that new installed app isn't being added to homescreen.

Launcher3 checks the install reason of the new app install and if it's only INSTALL_REASON_USER, then app icon will be added to homescreen. [0]

Reference:
0 - https://android.googlesource.com/platform/packages/apps/Launcher3/+/fb0952266e40939d6ef73604c1906c5317bee66c/src/com/android/launcher3/pm/InstallSessionHelper.java#237