### PR TITLE
proguard: do not obfuscate source code

### DIFF
--- a/proguard.pro
+++ b/proguard.pro
@@ -20,3 +20,6 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 -dontwarn okhttp3.internal.Util
+
+# Do not obfuscate source code
+-dontobfuscate


### PR DESCRIPTION
This was present before but got removed with commit db1a183a9bd34723ca5264d3effcdb1b655662fa.

Do not obfuscate the source code as the app is open source and obfuscation makes it harder to interpret stacktraces on crashes.